### PR TITLE
Fix heartbeat for process restarts

### DIFF
--- a/src/heartbeat.js
+++ b/src/heartbeat.js
@@ -107,7 +107,7 @@ export function workerHeartbeat(worker, { workerInterval }) {
 
   function heartbeatFn() {
     if (obj.heartbeatTimeout) {
-      clearTimeout(this.heartbeatTimeout);
+      clearTimeout(obj.heartbeatTimeout);
     }
     worker.send({ act: 'poolHallHeartbeat' });
     obj.heartbeatTimeout = setTimeout(heartbeatFn, interval);


### PR DESCRIPTION
When the process backing a worker exits, pool-hall replaces it with a
new process.  Process start up can take a nontrivial amount of time.
The heartbeat module was not aware of process replacement, so it
continued expecting heartbeats while the process was starting up.  This
can lead to a worker being reported as stalled, when it merely booting
up, leading to confusion over underlying problem (stalls = infinite
loops, process replacement = unhandled errors or the like).

This factors in worker state to monitoring and tweaks delta checking to
avoid reporting start up time.

/cc @andyfangdz @goatslacker @martinwin 